### PR TITLE
Add typeline to search, logging improvements, encoding workaround, dev cmd line optinos

### DIFF
--- a/src/ocr.py
+++ b/src/ocr.py
@@ -7,10 +7,10 @@ import os
 import json
 from difflib import SequenceMatcher
 from operator import itemgetter
-
+# TODO find logging library so we can set it to error,warn,info,debug levels
 
 class CardImage:
-	def __init__(self, filename, show_ocr_crops):
+	def __init__(self, filename, show_crops, do_ocr):
 		self.image = cv2.imread(filename)
 		self.image = cv2.resize(self.image, None, fx = 4, fy = 4, interpolation = cv2.INTER_CUBIC)
 		self.image = cv2.fastNlMeansDenoisingColored(self.image, None, 10, 10, 7, 21)
@@ -20,7 +20,8 @@ class CardImage:
 		#self.gray = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY | cv2.THRESH_OTSU)[1]
 		self.gray = self.image
 
-		self.show_crops = show_ocr_crops
+		self.show_crops = show_crops
+		self.do_ocr = do_ocr
 
 	def segment_and_scan(self):
 		"""Segment, preprocess, and OCR-scan an image given a filename
@@ -29,46 +30,67 @@ class CardImage:
 		"""
 
 		# croping images
+
+		print "Segmenting image...",
+		print "title...",
 		title_image = self.crop_segment( 0.04, 0.01, 0.85, 0.10 )
+		print "description...",
 		description_image = self.crop_segment( 0.05, 0.63, 0.95, 0.93 )
-		type_image = self.crop_segment( 0.05, 0.55, 0.95, 0.63 )
-		
+		print "type...",
+		type_image = self.crop_segment( 0.05, 0.55, 0.99, 0.63 )
+
+		print "series...",		
 		self.gray = cv2.resize(self.gray, None, fx = 4, fy = 4, interpolation = cv2.INTER_CUBIC)
 		series_image = self.crop_segment( 0, 0.93, 0.2, 1 )
+		print "done!"
 		
 		if self.show_crops:
+			print "Displaying cropped segments...",
 			cv2.imshow("Title", title_image)
 			cv2.imshow("Description", description_image)
 			cv2.imshow("Series", series_image)
 			cv2.imshow("Type", type_image)
+			print "done!"
+			print "Press any key to continue...",
 			cv2.waitKey(0)
+			print "good job!"
 
 		if self.do_ocr:
+			print "Starting OCR...",
+			print "title...",
 			title = self.scan_segment(title_image)
 			title = title.split("\n")[0]
 
+			print "description...",
 			description = self.scan_segment(description_image)
-
+			
+			print "series...",
 			series = self.scan_segment(series_image)
 			#series = series.split("\n")[0].split("/")
 
-		if len(title) < 4:
-			title_weight = 0.01
-		elif len(title) < 8:
-			title_weight = 0.5
-		else:
-			title_weight = 0.9
+			print "type...",
+			cardType = self.scan_segment(type_image)
 
-		return {
-			'title': title,
-			'description': description,
-			'weights': {
-				'title': title_weight,
-				'description': 1.0,
-				'type': 1.0 #TODO vary the weight
-			},
-			'series': series
-		}
+			if len(title) < 4:
+				title_weight = 0.01
+			elif len(title) < 8:
+				title_weight = 0.5
+			else:
+				title_weight = 0.9
+
+			return {
+				'title': title,
+				'description': description,
+				'weights': {
+					'title': title_weight,
+					'description': 1.0,
+					'type': 1.0 #TODO make sure this is correct
+				},
+				'type': cardType,
+				'series': series
+			}
+		
+		return None
 
 	def crop_segment(self, left, top, right, bottom):
 		h, w, channels = self.image.shape
@@ -131,20 +153,39 @@ if __name__ == '__main__':
 	ap = argparse.ArgumentParser()
 	ap.add_argument("-i", "--image", required=True,
 		help="path to input image to be OCR'd")
-	ap.add_argument("-s", "--show-ocr-crops", required=False, action="store_true", default=False,
+	ap.add_argument("-s", "--show-crops", required=False, action="store_true", default=False,
 		help="show the image results of OCR")
-	ap.add_argument("-k", "--skip-ocr", required=False, action="store_true", default=False,
+	ap.add_argument("-ko", "--skip-ocr", required=False, action="store_false", default=True, dest="do_ocr",
 		help="skips ocr scans")
-	args = vars(ap.parse_args())
+	ap.add_argument("-kl", "--skip-lookup", required=False, action="store_false", default=True, dest="do_lookup",
+		help="skips the database lookup")
+	parsed_args = ap.parse_args()
 
-	print "show_ocr=", args["show_ocr_crops"]
+	print "\nWelcome to MagicScan!"
+	print "(or whatever we end up calling it)"
+	print '\n', parsed_args
+	args = vars(parsed_args)
+	print
 
-	card_image = CardImage(args["image"], args["show_ocr_crops"])
-	scan = Bunch(card_image.segment_and_scan())
-	print "Scanned text:"
-	print scan.title, '/', scan.description, '/', scan.series
+	print "Loading image...",
+	card_image = CardImage(args["image"], args["show_crops"], args["do_ocr"])
+	print "done!"
 
-	db = CardDb('data/AllCards.json')
-	matches = db.scan_database([('name', scan.title, scan.weights['title']), ('text', scan.description, scan.weights['description'])])
-	print "Matches:"
-	CardDb.print_matches(matches)
+	segments = card_image.segment_and_scan()
+	hasScanData = not segments is None
+	if hasScanData:
+		scan = Bunch(segments)
+		print "\nScanned text:"
+		print scan.title, '/', scan.description, '/', scan.series, '/', scan.type
+
+	if args["do_lookup"] and hasScanData:
+		print "Loading DB...",
+		db = CardDb('data/AllCards.json')
+		print "done!"
+
+		print "Finding card matches...",
+		matches = db.scan_database([('name', scan.title, scan.weights['title']), ('text', scan.description, scan.weights['description'])])
+		print "done!"
+		print "\nMatches:"
+		CardDb.print_matches(matches)
+	

--- a/src/ocr.py
+++ b/src/ocr.py
@@ -153,7 +153,7 @@ class CardDb:
 
 if __name__ == '__main__':
 	try:
-		print u'\u2014' # TODO how to check encoding w/o printing unecessary characters
+		u'\u2014'.encode(sys.stdout.encoding)
 	except UnicodeEncodeError as uee:
 		# TODO improve this message
 		print "Current encoding not supported. Use a terminal which supports unicode."

--- a/src/ocr.py
+++ b/src/ocr.py
@@ -11,7 +11,7 @@ import sys
 # TODO find logging library so we can set it to error,warn,info,debug levels
 
 class CardImage:
-	def __init__(self, filename, show_crops, do_ocr):
+	def __init__(self, filename, show_crops=False, do_ocr=True):
 		self.image = cv2.imread(filename)
 		self.image = cv2.resize(self.image, None, fx = 4, fy = 4, interpolation = cv2.INTER_CUBIC)
 		self.image = cv2.fastNlMeansDenoisingColored(self.image, None, 10, 10, 7, 21)
@@ -202,4 +202,4 @@ if __name__ == '__main__':
 		print "done!"
 		print "\nMatches:"
 		CardDb.print_matches(matches)
-	
+


### PR DESCRIPTION
Added cmd line options for dev: --skip-ocr, --skip-lookup, --show-crops
These options skip OCR process, skip DB lookup and show the cropped image segments, respectively.

I added the card-type image segment and pumped it through OCR and DB search.

It turns out the DB has an em dash in the Type value, e.g. Enchantment — Aura, this was causing UnicodeEncodingErrors because the VS Code terminal defaults to cp437. Luckily, cp1252 was available (cp65001 was not) and I used chcp from the command line to fix. I added a quick test at the beginning of the main method to be sure the encoding is unicode.

Also added a bunch of logging for each step of processing. Loading the image takes the longest.

See TODOs/FIXMEs throughout.